### PR TITLE
Fix build-tokens.js array values error

### DIFF
--- a/components/scripts/build-tokens.js
+++ b/components/scripts/build-tokens.js
@@ -17,7 +17,7 @@ function transformTokens(parentKey, object) {
 
       return `${tokensTransformed}\n\t--${toKebabCase(
         customProperty
-      )}: ${value.join()};`
+      )}: ${value.join(', ')};`
     } else if (typeof value === 'object') {
       const customProperty = parentKey
         ? `${parentKey}-${objectKey}`

--- a/components/scripts/build-tokens.js
+++ b/components/scripts/build-tokens.js
@@ -10,7 +10,15 @@ function transformTokens(parentKey, object) {
   return objectKeys.reduce((tokensTransformed, objectKey) => {
     const value = object[objectKey]
 
-    if (typeof value === 'object') {
+    if (Array.isArray(value)) {
+      const customProperty = parentKey
+        ? `${parentKey}-${objectKey}`
+        : `${objectKey}`
+
+      return `${tokensTransformed}\n\t--${toKebabCase(
+        customProperty
+      )}: ${value.join()};`
+    } else if (typeof value === 'object') {
       const customProperty = parentKey
         ? `${parentKey}-${objectKey}`
         : `${objectKey}`

--- a/components/styles/tokens.css
+++ b/components/styles/tokens.css
@@ -144,10 +144,7 @@
 	--screens-max-lg: 1023px;
 	--screens-max-xl: 1279px;
 	
-	
-	--font-family-sans-0: Quicksand;
-	--font-family-sans-1: Arial;
-	--font-family-sans-2: sans-serif;
+	--font-family-sans: Quicksand,Arial,sans-serif;
 	
 	--font-size-base: 10px;
 	--font-size-xs: .75rem;

--- a/components/styles/tokens.css
+++ b/components/styles/tokens.css
@@ -144,7 +144,7 @@
 	--screens-max-lg: 1023px;
 	--screens-max-xl: 1279px;
 	
-	--font-family-sans: Quicksand,Arial,sans-serif;
+	--font-family-sans: Quicksand, Arial, sans-serif;
 	
 	--font-size-base: 10px;
 	--font-size-xs: .75rem;


### PR DESCRIPTION
Fixing build-tokens.js array values error. Now array values are transformed in comma-separated token values.